### PR TITLE
:wrench: Allow npm ^11.9.0 in devEngines to unblock CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "devEngines": {
     "packageManager": {
       "name": "npm",
-      "version": "11.9.0",
+      "version": "^11.9.0",
       "onFail": "download"
     }
   },


### PR DESCRIPTION
The exact "11.9.0" pin broke after GitHub Actions runners upgraded npm to 11.11.0 around 2026-04-07, causing EBADDEVENGINES in actions/setup-node@v6 cache setup across build/lint/format/e2e.

Switch to the caret range so patch updates of npm are accepted.