### PR TITLE
:wrench: Remove devEngines to unblock Dependabot

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,13 +5,6 @@
   "engines": {
     "node": "24"
   },
-  "devEngines": {
-    "packageManager": {
-      "name": "npm",
-      "version": "^11.9.0",
-      "onFail": "download"
-    }
-  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
Corepack (used internally by Dependabot) does not accept semver ranges in devEngines.packageManager.version and errors out with "Invalid package manager specification; expected a semver version".

Tracked upstream:
- nodejs/corepack#729
- dependabot/dependabot-core#13722

The engines.node field still enforces the Node.js version requirement.