### PR TITLE
:sparkles: Flatten solid entries when extracting

### DIFF
--- a/e2e/extract.spec.ts
+++ b/e2e/extract.spec.ts
@@ -175,3 +175,94 @@ test.describe("Create and Extract round-trip", () => {
     expect(extractedContent).toBe(TEST_CONTENT);
   });
 });
+
+test.describe("Solid mode round-trip", () => {
+  const FIXTURE_DIR = path.join(__dirname, "fixtures", "extract");
+  const FILE_A = path.join(FIXTURE_DIR, "solid-a.txt");
+  const FILE_B = path.join(FIXTURE_DIR, "solid-b.txt");
+  const CONTENT_A = "solid file A content";
+  const CONTENT_B = "solid file B content";
+
+  test.beforeEach(() => {
+    fs.mkdirSync(FIXTURE_DIR, { recursive: true });
+    fs.writeFileSync(FILE_A, CONTENT_A);
+    fs.writeFileSync(FILE_B, CONTENT_B);
+  });
+
+  test("plain solid archive round-trips both files", async ({ page }) => {
+    await page.goto("/create/");
+    await expect(page.locator("h1")).toBeVisible();
+
+    await page.locator('input[type="file"]').setInputFiles([FILE_A, FILE_B]);
+    await page.getByLabel("Solid mode (compress all files together)").check();
+    await page.getByRole("button", { name: "Create" }).click();
+
+    const downloadLink = page.locator("a[download='archive.pna']");
+    await expect(downloadLink).toBeVisible({ timeout: 15_000 });
+    const href = await downloadLink.getAttribute("href");
+    const archiveBuffer = await fetchBlobAsBytes(page, href!);
+    const archivePath = path.join(FIXTURE_DIR, "solid.pna");
+    fs.writeFileSync(archivePath, Buffer.from(archiveBuffer));
+
+    await page.goto("/extract/");
+    await page.locator('input[type="file"]').setInputFiles(archivePath);
+    await page.getByRole("button", { name: "Extract" }).click();
+
+    const linkA = page.locator("a[download='solid-a.txt']");
+    const linkB = page.locator("a[download='solid-b.txt']");
+    await expect(linkA).toBeVisible({ timeout: 15_000 });
+    await expect(linkB).toBeVisible();
+
+    expect(
+      await fetchBlobAsText(page, (await linkA.getAttribute("href"))!),
+    ).toBe(CONTENT_A);
+    expect(
+      await fetchBlobAsText(page, (await linkB.getAttribute("href"))!),
+    ).toBe(CONTENT_B);
+  });
+
+  test("encrypted solid archive prompts for password and decrypts", async ({
+    page,
+  }) => {
+    const password = "solid_e2e_password";
+
+    await page.goto("/create/");
+    await expect(page.locator("h1")).toBeVisible();
+
+    await page.locator('input[type="file"]').setInputFiles([FILE_A, FILE_B]);
+    await page.getByLabel("Solid mode (compress all files together)").check();
+    await page.getByLabel("Encrypt archive").check();
+    await page.locator('input[type="password"]').fill(password);
+    await page.getByRole("button", { name: "Create" }).click();
+
+    const downloadLink = page.locator("a[download='archive.pna']");
+    await expect(downloadLink).toBeVisible({ timeout: 15_000 });
+    const href = await downloadLink.getAttribute("href");
+    const archiveBuffer = await fetchBlobAsBytes(page, href!);
+    const archivePath = path.join(FIXTURE_DIR, "solid-encrypted.pna");
+    fs.writeFileSync(archivePath, Buffer.from(archiveBuffer));
+
+    await page.goto("/extract/");
+    await page.locator('input[type="file"]').setInputFiles(archivePath);
+    await page.getByRole("button", { name: "Extract" }).click();
+
+    // Password prompt must appear because the solid block is encrypted.
+    await expect(page.locator("#archive-password")).toBeVisible({
+      timeout: 10_000,
+    });
+    await page.locator("#archive-password").fill(password);
+    await page.getByRole("button", { name: "Decrypt & Extract" }).click();
+
+    const linkA = page.locator("a[download='solid-a.txt']");
+    const linkB = page.locator("a[download='solid-b.txt']");
+    await expect(linkA).toBeVisible({ timeout: 15_000 });
+    await expect(linkB).toBeVisible();
+
+    expect(
+      await fetchBlobAsText(page, (await linkA.getAttribute("href"))!),
+    ).toBe(CONTENT_A);
+    expect(
+      await fetchBlobAsText(page, (await linkB.getAttribute("href"))!),
+    ).toBe(CONTENT_B);
+  });
+});

--- a/pna_wasm/src/lib.rs
+++ b/pna_wasm/src/lib.rs
@@ -8,6 +8,42 @@ fn to_js_error(e: io::Error) -> JsValue {
     JsValue::from_str(&e.to_string())
 }
 
+fn build_write_options(
+    password: Option<&str>,
+    encryption: Option<&str>,
+) -> io::Result<libpna::WriteOptions> {
+    let mut options = libpna::WriteOptions::builder();
+    options.compression(libpna::Compression::ZStandard);
+    match (password, encryption) {
+        (Some(pw), Some(enc)) => {
+            let algo = match enc {
+                "aes" => libpna::Encryption::Aes,
+                "camellia" => libpna::Encryption::Camellia,
+                other => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        format!(
+                            "Unsupported encryption algorithm: '{other}'. Use 'aes' or 'camellia'."
+                        ),
+                    ));
+                }
+            };
+            options
+                .encryption(algo)
+                .cipher_mode(libpna::CipherMode::CTR)
+                .password(Some(pw));
+        }
+        (None, None) => {}
+        _ => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "Password and encryption algorithm must both be provided or both be omitted.",
+            ));
+        }
+    }
+    Ok(options.build())
+}
+
 #[wasm_bindgen]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Entry(libpna::NormalEntry);
@@ -20,37 +56,9 @@ impl Entry {
         password: Option<&str>,
         encryption: Option<&str>,
     ) -> io::Result<Self> {
-        let mut options = libpna::WriteOptions::builder();
-        options.compression(libpna::Compression::ZStandard);
-        match (password, encryption) {
-            (Some(pw), Some(enc)) => {
-                let algo = match enc {
-                    "aes" => libpna::Encryption::Aes,
-                    "camellia" => libpna::Encryption::Camellia,
-                    other => {
-                        return Err(io::Error::new(
-                            io::ErrorKind::InvalidInput,
-                            format!(
-                                "Unsupported encryption algorithm: '{other}'. Use 'aes' or 'camellia'."
-                            ),
-                        ));
-                    }
-                };
-                options
-                    .encryption(algo)
-                    .cipher_mode(libpna::CipherMode::CTR)
-                    .password(Some(pw));
-            }
-            (None, None) => {}
-            _ => {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidInput,
-                    "Password and encryption algorithm must both be provided or both be omitted.",
-                ));
-            }
-        }
+        let options = build_write_options(password, encryption)?;
         let mut entry =
-            libpna::EntryBuilder::new_file(libpna::EntryName::from_lossy(name), options.build())?;
+            libpna::EntryBuilder::new_file(libpna::EntryName::from_lossy(name), options)?;
         entry.write_all(data)?;
         Ok(Self(entry.build()?))
     }
@@ -127,6 +135,30 @@ impl Archive {
             archive.add_entry(pna_entry.0).unwrap();
         }
         Self(archive.finalize().unwrap())
+    }
+
+    pub fn create_solid(
+        entries: Vec<Entry>,
+        password: Option<String>,
+        encryption: Option<String>,
+    ) -> Result<Self, JsValue> {
+        utils::set_panic_hook();
+        Self::_create_solid(entries, password.as_deref(), encryption.as_deref())
+            .map_err(to_js_error)
+    }
+
+    fn _create_solid(
+        entries: Vec<Entry>,
+        password: Option<&str>,
+        encryption: Option<&str>,
+    ) -> io::Result<Self> {
+        let options = build_write_options(password, encryption)?;
+        let vec = Vec::new();
+        let mut archive = libpna::Archive::write_solid_header(vec, options)?;
+        for pna_entry in entries {
+            archive.add_entry(pna_entry.0)?;
+        }
+        Ok(Self(archive.finalize()?))
     }
 
     pub async fn from(f: web_sys::Blob) -> Self {
@@ -252,5 +284,46 @@ mod tests {
     async fn pna_encrypted_mismatched_args() {
         assert!(Entry::from("f.txt", b"data", Some("pw"), None).is_err());
         assert!(Entry::from("f.txt", b"data", None, Some("aes")).is_err());
+    }
+
+    #[wasm_bindgen_test]
+    async fn pna_solid() {
+        let entries = vec![
+            Entry::from("a.txt", b"hello", None, None).unwrap(),
+            Entry::from("b.txt", b"world", None, None).unwrap(),
+        ];
+        let archive = Archive::create_solid(entries, None, None).unwrap();
+        assert!(!archive.is_encrypted());
+        let mut entries = archive.entries(None).await.unwrap().array();
+        let entry = entries.pop().unwrap();
+        assert_eq!(entry.to_vec(None).unwrap().as_slice(), b"world");
+        let entry = entries.pop().unwrap();
+        assert_eq!(entry.to_vec(None).unwrap().as_slice(), b"hello");
+    }
+
+    #[wasm_bindgen_test]
+    async fn pna_solid_encrypted() {
+        let password = "solid_pw";
+        let entries = vec![
+            Entry::from("a.txt", b"first", None, None).unwrap(),
+            Entry::from("b.txt", b"second", None, None).unwrap(),
+        ];
+        let archive =
+            Archive::create_solid(entries, Some(password.to_string()), Some("aes".to_string()))
+                .unwrap();
+        assert!(archive.is_encrypted());
+        // Without the password, iteration should fail.
+        assert!(archive.entries(None).await.is_err());
+        // With the right password, the solid block is decrypted and flattened.
+        let mut entries = archive
+            .entries(Some(password.to_string()))
+            .await
+            .unwrap()
+            .array();
+        assert_eq!(entries.len(), 2);
+        let entry = entries.pop().unwrap();
+        assert_eq!(entry.to_vec(None).unwrap().as_slice(), b"second");
+        let entry = entries.pop().unwrap();
+        assert_eq!(entry.to_vec(None).unwrap().as_slice(), b"first");
     }
 }

--- a/pna_wasm/src/lib.rs
+++ b/pna_wasm/src/lib.rs
@@ -136,27 +136,37 @@ impl Archive {
         Self(data.to_vec())
     }
 
-    fn _entries(&self) -> io::Result<Vec<Entry>> {
+    fn _entries(&self, password: Option<&[u8]>) -> io::Result<Vec<Entry>> {
         let mut archive = libpna::Archive::read_header(self.0.as_slice())?;
         let entries = archive
-            .entries_with_password(None)
+            .entries_with_password(password)
             .map(|r| r.map(Entry))
             .collect::<io::Result<Vec<_>>>()?;
         Ok(entries)
     }
 
-    pub async fn entries(&self) -> Result<Entries, JsValue> {
-        self._entries().map(Entries).map_err(to_js_error)
+    pub async fn entries(&self, password: Option<String>) -> Result<Entries, JsValue> {
+        self._entries(password.as_deref().map(str::as_bytes))
+            .map(Entries)
+            .map_err(to_js_error)
     }
 
     pub fn is_encrypted(&self) -> bool {
-        self._entries()
-            .map(|it| it.iter().any(|it| it.is_encrypted()))
-            .unwrap_or(false)
+        let Ok(mut archive) = libpna::Archive::read_header(self.0.as_slice()) else {
+            return false;
+        };
+        archive.entries().any(|r| match r {
+            Ok(libpna::ReadEntry::Normal(n)) => n.header().encryption() != libpna::Encryption::No,
+            Ok(libpna::ReadEntry::Solid(s)) => s.encryption() != libpna::Encryption::No,
+            Err(_) => false,
+        })
     }
 
-    pub async fn extract_to_entries(blob: web_sys::Blob) -> Result<Entries, JsValue> {
-        Self::from(blob).await.entries().await
+    pub async fn extract_to_entries(
+        blob: web_sys::Blob,
+        password: Option<String>,
+    ) -> Result<Entries, JsValue> {
+        Self::from(blob).await.entries(password).await
     }
 
     pub fn to_u8array(&self) -> js_sys::Uint8Array {
@@ -173,7 +183,7 @@ mod tests {
     async fn pna_empty() {
         let entries = vec![];
         let archive = Archive::create(entries);
-        let entries = archive.entries().await.unwrap().array();
+        let entries = archive.entries(None).await.unwrap().array();
         assert_eq!(entries.len(), 0);
     }
 
@@ -185,7 +195,7 @@ mod tests {
         ];
         let archive = Archive::create(entries);
         assert!(!archive.is_encrypted());
-        let mut entries = archive.entries().await.unwrap().array();
+        let mut entries = archive.entries(None).await.unwrap().array();
         let entry = entries.pop().unwrap();
         assert_eq!(entry.to_vec(None).unwrap().as_slice(), b"");
         let entry = entries.pop().unwrap();
@@ -201,7 +211,7 @@ mod tests {
             ];
         let archive = Archive::create(entries);
         assert!(archive.is_encrypted());
-        let mut entries = archive.entries().await.unwrap().array();
+        let mut entries = archive.entries(None).await.unwrap().array();
         let entry = entries.pop().unwrap();
         assert!(entry.is_encrypted());
         assert_eq!(
@@ -216,7 +226,7 @@ mod tests {
             vec![Entry::from("cam.txt", b"camellia", Some("pw"), Some("camellia")).unwrap()];
         let archive = Archive::create(entries);
         assert!(archive.is_encrypted());
-        let entry = &archive.entries().await.unwrap().array()[0];
+        let entry = &archive.entries(None).await.unwrap().array()[0];
         assert_eq!(
             entry.to_vec(Some("pw".to_string())).unwrap().as_slice(),
             b"camellia"
@@ -228,7 +238,7 @@ mod tests {
         let entries =
             vec![Entry::from("secret.txt", b"data", Some("correct"), Some("aes")).unwrap()];
         let archive = Archive::create(entries);
-        let entry = &archive.entries().await.unwrap().array()[0];
+        let entry = &archive.entries(None).await.unwrap().array()[0];
         assert!(entry.to_vec(Some("wrong".to_string())).is_err());
     }
 

--- a/pna_wasm/src/lib.rs
+++ b/pna_wasm/src/lib.rs
@@ -139,12 +139,8 @@ impl Archive {
     fn _entries(&self) -> io::Result<Vec<Entry>> {
         let mut archive = libpna::Archive::read_header(self.0.as_slice())?;
         let entries = archive
-            .entries()
-            .filter_map(|result| match result {
-                Ok(libpna::ReadEntry::Normal(entry)) => Some(Ok(Entry(entry))),
-                Ok(libpna::ReadEntry::Solid(_)) => None,
-                Err(e) => Some(Err(e)),
-            })
+            .entries_with_password(None)
+            .map(|r| r.map(Entry))
             .collect::<io::Result<Vec<_>>>()?;
         Ok(entries)
     }

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -40,6 +40,7 @@ function Create(pna: typeof import("pna")) {
   const [files, setFiles] = useState<File[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [isProcessing, setIsProcessing] = useState(false);
+  const [useSolid, setUseSolid] = useState(false);
   const [useEncryption, setUseEncryption] = useState(false);
   const [password, setPassword] = useState("");
   const [algorithm, setAlgorithm] = useState<Algorithm>("aes");
@@ -138,6 +139,14 @@ function Create(pna: typeof import("pna")) {
         <label className={styles["encryption-toggle"]}>
           <input
             type="checkbox"
+            checked={useSolid}
+            onChange={(e) => setUseSolid(e.target.checked)}
+          />
+          Solid mode (compress all files together)
+        </label>
+        <label className={styles["encryption-toggle"]}>
+          <input
+            type="checkbox"
             checked={useEncryption}
             onChange={(e) => {
               setUseEncryption(e.target.checked);
@@ -183,12 +192,18 @@ function Create(pna: typeof import("pna")) {
             const trimmedPassword = password.trim();
             const objects = await Promise.all(
               files.map(async (f) =>
-                useEncryption
+                useEncryption && !useSolid
                   ? pna.Entry.new_encrypted(f, trimmedPassword, algorithm)
                   : pna.Entry.new(f),
               ),
             );
-            const a = pna.Archive.create(objects);
+            const a = useSolid
+              ? pna.Archive.create_solid(
+                  objects,
+                  useEncryption ? trimmedPassword : undefined,
+                  useEncryption ? algorithm : undefined,
+                )
+              : pna.Archive.create(objects);
             const result = a.to_u8array();
             const duration = performance.now() - startTime;
             const originalSize = files.reduce((sum, f) => sum + f.size, 0);

--- a/src/lib/extractWorker.ts
+++ b/src/lib/extractWorker.ts
@@ -17,7 +17,7 @@ worker.addEventListener(
     const [archive, password] = e.data;
     try {
       const pna = await getPna();
-      let entries = await pna.Archive.extract_to_entries(archive);
+      let entries = await pna.Archive.extract_to_entries(archive, password);
       await Promise.allSettled(
         entries.array().map(async (entry, idx) => {
           try {


### PR DESCRIPTION
Replaces the filter_map(ReadEntry::Normal) iteration with entries_with_password(None) so that PNA archives produced by external tools using solid mode are read into their constituent NormalEntry items, instead of being silently dropped from the entry list shown on /extract.

Encrypted solid blocks still surface as an error at entries() time, which the UI can route to the password prompt; this is a better UX than silently presenting an empty entry list.