### PR TITLE
:bug: Fix favicon paths for GitHub Pages

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,10 +2,15 @@ import "./globals.css";
 import type { Metadata } from "next";
 import SiteHeader from "@/components/SiteHeader";
 
+const basePath = process.env.BASE_PATH ?? "";
+
 export const metadata: Metadata = {
   title: "PNA Demo — Portable Network Archive in Your Browser",
   description:
     "Create and extract PNA archives directly in your browser using WebAssembly. No uploads, no server — everything runs locally.",
+  icons: {
+    icon: [{ url: `${basePath}/favicon.svg`, type: "image/svg+xml" }],
+  },
 };
 
 export default function RootLayout({
@@ -15,9 +20,6 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <head>
-        <link rel="shortcut icon" type="image/svg+xml" href="favicon.svg" />
-      </head>
       <body>
         <SiteHeader />
         {children}

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -2,12 +2,14 @@ import Image from "next/image";
 import Link from "next/link";
 import styles from "./SiteHeader.module.css";
 
+const basePath = process.env.BASE_PATH ?? "";
+
 const SiteHeader: React.FC = () => {
   return (
     <header className={styles["header"]}>
       <Link href="/" className={styles["brand"]}>
         <Image
-          src="/favicon.svg"
+          src={`${basePath}/favicon.svg`}
           alt=""
           width={36}
           height={36}


### PR DESCRIPTION
## Summary

- prefix the favicon metadata URL with the configured `BASE_PATH`
- prefix the header logo URL with the same deployment base path
- use the Next.js Metadata API for the favicon declaration

## Root cause

Files served from `public` are not automatically prefixed by Next.js `basePath`. The header used the domain-root path `/favicon.svg`, while the metadata used a relative `favicon.svg` path that resolved incorrectly on nested routes. On GitHub Pages, both forms could miss the repository subpath.

## Impact

The favicon and header logo now resolve to `/wasm-demo/favicon.svg` across the root, `/create/`, and `/extract/` pages when deployed to GitHub Pages, while local builds continue to use `/favicon.svg`.

## Validation

- `npm run format:check`
- `npm run lint` (passes with one pre-existing warning in `eslint.config.mjs`)
- generated a static export with `BASE_PATH=/wasm-demo` and verified all three pages reference `/wasm-demo/favicon.svg`

## Local build note

The repository's existing generated `pna_wasm/pkg` is stale relative to the Rust source, and the local clang does not support the `wasm32-unknown-unknown` target, so the standard Wasm rebuild could not complete locally. The favicon-specific static export was validated independently.
